### PR TITLE
tweak the padding from the top and bottom of sections to be 'equal'

### DIFF
--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -62,8 +62,8 @@
 
 <style>
 	.non-hero {
-		padding-top: 7rem;
-		padding-bottom: 7rem;
+		padding-top: 8.2rem;
+		padding-bottom: 8.2rem;
 
 		display: flex;
 		align-items: center;

--- a/src/styles/text.scss
+++ b/src/styles/text.scss
@@ -11,8 +11,8 @@ h2 {
 	color: var(--text-colour);
 	font-family: 'Raleway', sans-serif;
 	font-weight: 400;
-	line-height: 5.5rem;
 	margin: 0;
+	margin-bottom: 1.2rem;
 }
 
 h3 {


### PR DESCRIPTION
Remove the line-spacing, use margin-bottom instead, and add to the padding of the top and bottom of sections so they're "equal" after taking the text's spacing into account.