### PR TITLE
use dvh if supported

### DIFF
--- a/src/lib/components/Greeter.svelte
+++ b/src/lib/components/Greeter.svelte
@@ -49,6 +49,12 @@
 		background-color: var(--red-accent);
 	}
 
+	@supports (height: 100dvh) {
+		.body {
+			height: 100dvh;
+		}
+	}
+
 	@media screen and (max-width: 650px) {
 		.body {
 			min-height: 35rem;


### PR DESCRIPTION
Uses `height: 100dvh;` for the greeter/hero if it is supported by the browser for dynamic `vh`.